### PR TITLE
Adding position type and z-index

### DIFF
--- a/src/components/ControlPanel.js
+++ b/src/components/ControlPanel.js
@@ -4,7 +4,8 @@ class ControlPanel extends Component {
 
     divStyle = {
         background: 'red',
-
+        position: 'absolute',
+        zIndex: '50',
       };
 
     render() {


### PR DESCRIPTION
The map that is injected is created as an absolutely positioned object, so you'll want to have your control panel parent element also be positioned absolute. The second thing is to set the z-index attribute higher than 1, because that's the default level. I set it to 10 because it isn't uncommon to increment by 10s just to add some breathing room if you need to add something between them later.